### PR TITLE
Raise fastcgi buffers

### DIFF
--- a/mainline/scripts/etc/nginx/conf.d/fastcgi.conf
+++ b/mainline/scripts/etc/nginx/conf.d/fastcgi.conf
@@ -1,0 +1,2 @@
+fastcgi_buffers 16 16k;
+fastcgi_buffer_size 32k;

--- a/stable/scripts/etc/nginx/conf.d/fastcgi.conf
+++ b/stable/scripts/etc/nginx/conf.d/fastcgi.conf
@@ -1,0 +1,2 @@
+fastcgi_buffers 16 16k;
+fastcgi_buffer_size 32k;


### PR DESCRIPTION
... to prevent "upstream sent too big header while reading response header from upstream" errors, resulting in a 502 Bad Gateway response.

Occasionally occurs on Symfony 5+ applications, when an error page is displayed. Sometimes the payload is large enough to cause these errors.